### PR TITLE
[infra] replace hardcoded db path by gloabal config module

### DIFF
--- a/feature_gen/base_feature.py
+++ b/feature_gen/base_feature.py
@@ -3,6 +3,7 @@ from fmp_data import FMPPriceLoader
 import pandas as pd
 from typing import Optional, Dict, List
 import sqlite3
+from utils.config import FMP_DB_PATH
 from datetime import datetime
 import numpy as np
 from fmp_data import Dataset
@@ -37,7 +38,7 @@ class FinancialFeatureBase(ABC):
     including database access, symbol retrieval, and sector quantile calculation.
     """
     
-    def __init__(self, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+    def __init__(self, db_path: str = FMP_DB_PATH):
         """
         Initialize the feature generator.
         

--- a/fmp_crawler/base_fmp_crawler.py
+++ b/fmp_crawler/base_fmp_crawler.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 import aiohttp
@@ -7,14 +6,13 @@ import sqlite3
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any, List
 from utils.logging_config import setup_logging as setup_global_logging
+from utils.config import FMP_API_KEY
 
 
 class BaseFMPCrawler:
     def __init__(self, db_path: str):
         self.skip_existing = True
-        self.api_key = os.getenv('FMP_API_KEY')
-        if not self.api_key:
-            raise ValueError("FMP_API_KEY environment variable not set")
+        self.api_key = FMP_API_KEY
 
         self.base_url = "https://financialmodelingprep.com/stable"
         self.last_request_time = 0

--- a/fmp_data/dataset.py
+++ b/fmp_data/dataset.py
@@ -13,6 +13,7 @@ import numpy as np
 from fmp_data.offline_data import OfflineData
 from fmp_data.metric_calculator import DERIVED_METRICS
 from utils.logging_config import setup_logging as setup_global_logging
+from utils.config import FMP_DB_PATH
 
 class Dataset:
     """
@@ -25,7 +26,7 @@ class Dataset:
     
     def __init__(self, symbols: Union[str, List[str]], metrics: List[str], start_date: str, end_date: str,
                  with_price: bool = False,
-                 db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+                 db_path: str = FMP_DB_PATH):
         """
         Initialize the dataset.
         

--- a/fmp_data/offline_data.py
+++ b/fmp_data/offline_data.py
@@ -11,10 +11,11 @@ from datetime import datetime, date, timedelta
 from typing import Dict, List, Any, Optional, Union, Set, Tuple
 import pandas as pd
 import sqlite3
+from utils.config import FMP_DB_PATH
 
 class OfflineData:
     def __init__(self, symbol: Union[str, List[str]], metrics: List[str], for_date: Union[str, List[str]] = None, 
-                 start_date: str = None, end_date: str = None, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+                 start_date: str = None, end_date: str = None, db_path: str = FMP_DB_PATH):
         """Initialize Dataset object.
         
         Args:
@@ -187,7 +188,7 @@ class OfflineData:
             yield symbol, result
     
     @classmethod
-    def historical_tradable_price(cls, symbol: str, start_date: str, end_date: str, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+    def historical_tradable_price(cls, symbol: str, start_date: str, end_date: str, db_path: str = FMP_DB_PATH):
         """Get historical tradable price for a symbol in a date range.
         
         If there are gaps in the price data (days without data), the method will fill
@@ -232,7 +233,7 @@ class OfflineData:
             return merged
 
     @classmethod
-    def get_us_active_stocks(cls, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db') -> List[str]:
+    def get_us_active_stocks(cls, db_path: str = FMP_DB_PATH) -> List[str]:
         with sqlite3.connect(f'file:{db_path}?mode=ro', uri=True) as conn:
             query = """
             SELECT symbol

--- a/fmp_data_legacy.py
+++ b/fmp_data_legacy.py
@@ -5,6 +5,7 @@ from datetime import datetime, date, timedelta
 import logging
 from typing import List, Dict, Union
 import sqlite3
+from utils.config import FMP_DB_PATH
 
 
 BEFORE_PRICE = 'before_price'
@@ -13,7 +14,7 @@ PRICE_METRICS = {BEFORE_PRICE, AFTER_PRICE}
 
 class Dataset:
     def __init__(self, symbol: Union[str, List[str]], metrics: Dict[str, str], for_date: Union[str, List[str]] = None, 
-                 start_date: str = None, end_date: str = None, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+                 start_date: str = None, end_date: str = None, db_path: str = FMP_DB_PATH):
         """Initialize Dataset object.
         
         Args:
@@ -274,13 +275,13 @@ class Dataset:
 
 
 class FMPPriceLoader:
-    def __init__(self, price_tolerance_days: int = 4, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+    def __init__(self, price_tolerance_days: int = 4, db_path: str = FMP_DB_PATH):
         """Initialize database connection
 
         Args:
             price_tolerance_days (int): Maximum number of days to search for a price when given date has no data. Used
                 in get_last_available_price and get_next_available_price
-            db_path (str): Path to the SQLite database file. Defaults to '/Users/jluan/code/finance/data/fmp_data.db'
+            db_path (str): Path to the SQLite database file. Defaults to the value from config module
 
         Raises:
             FileNotFoundError: If the database file doesn't exist
@@ -624,6 +625,6 @@ class FMPPriceLoader:
         return set(row['symbol'] for row in self.cursor.fetchall())        
 
 def fmp(sql):
-    db = sqlite3.connect('/Users/jluan/code/finance/data/fmp_data.db')
+    db = sqlite3.connect(FMP_DB_PATH)
     df = pd.read_sql_query(sql, db)
     return df        

--- a/fmp_fetch/fmp_api.py
+++ b/fmp_fetch/fmp_api.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 import requests
@@ -6,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 from functools import cache
 from utils.logging_config import setup_logging as setup_global_logging
+from utils.config import FMP_API_KEY
 
 
 class FMPAPI:
@@ -14,9 +14,7 @@ class FMPAPI:
     This class provides synchronous versions of the functions used in fmp_crawler.
     """
     def __init__(self):
-        self.api_key = os.getenv('FMP_API_KEY')
-        if not self.api_key:
-            raise ValueError("FMP_API_KEY environment variable not set")
+        self.api_key = FMP_API_KEY
 
         self.base_url = "https://financialmodelingprep.com/stable"
         self.last_request_time = 0

--- a/research/interday_trading.py
+++ b/research/interday_trading.py
@@ -6,10 +6,11 @@ from datetime import datetime, date, timedelta
 from tqdm import tqdm
 from fmp_data_legacy import FMPPriceLoader, Dataset
 import numpy as np
+from utils.config import FMP_DB_PATH
 
 
 class InterdayTrading:
-    def __init__(self, begin_date: str, end_date: str, db_path: str = '/Users/jluan/code/finance/data/fmp_data.db'):
+    def __init__(self, begin_date: str, end_date: str, db_path: str = FMP_DB_PATH):
         """
         Initialize InterdayTrading with date range and load valid stocks.
         Args:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,8 +2,10 @@ import pytest
 import tempfile
 import sqlite3
 import os
+import sys
+from utils.config import FMP_DB_PATH
 
-PRODUCTION_DB_PATH = '/Users/jluan/code/finance/data/fmp_data.db'
+PRODUCTION_DB_PATH = FMP_DB_PATH
 
 def get_production_schema():
     """Get schema from production database."""

--- a/test/utils/test_config.py
+++ b/test/utils/test_config.py
@@ -1,0 +1,22 @@
+"""
+Test for the config module.
+
+This test simply tries to import the mandatory configuration variables.
+If the test fails, it means the current environment is not properly configured.
+"""
+
+import pytest
+
+
+def test_mandatory_configs_are_set():
+    """
+    Test that mandatory configuration variables are set in the environment.
+    
+    This test will fail if the environment variables are not set, indicating
+    that the environment is not properly configured for running the application.
+    """
+    from utils.config import FMP_DB_PATH, FMP_API_KEY
+    
+    # Simply check that the values are not empty
+    assert FMP_DB_PATH, "FMP_DB_PATH environment variable is not set. This is mandatory for running the application."
+    assert FMP_API_KEY, "FMP_API_KEY environment variable is not set. This is mandatory for running the application."

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,19 @@
+"""
+Configuration module for the finance project.
+
+This module provides centralized access to configuration settings,
+primarily loaded from environment variables with sensible defaults.
+"""
+
+import os
+
+def read_config_from_env_or_die(name: str):
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"Mandatory environment variable {name} is not set")
+    return value
+
+
+# For direct imports like: from utils.config import DB_PATH, API_KEY
+FMP_DB_PATH = read_config_from_env_or_die("FMP_DB_PATH")
+FMP_API_KEY = read_config_from_env_or_die("FMP_API_KEY")


### PR DESCRIPTION
This PR added a config module that load global configs from env variables. Right now it reads two configs:

* The default sqlite DB path
* The FMP API key

Previously default DB path is hardcoded. Those hardcoded code are updated to use this config. In the future, you can just set `FMP_DB_PATH` and `FMP_API_KEY` in your env variable and run any code.

@wanshoupu 