### PR TITLE
[infra] add batch quote api for screener on real time price data

### DIFF
--- a/fmp_fetch/fmp_api.py
+++ b/fmp_fetch/fmp_api.py
@@ -2,7 +2,7 @@ import time
 import logging
 import requests
 from datetime import datetime, timedelta
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from functools import cache
 from utils.logging_config import setup_logging as setup_global_logging
 from utils.config import FMP_API_KEY
@@ -187,6 +187,24 @@ class FMPAPI:
     def spx_constituents(self):
         spx = self.make_request('sp500-constituent')
         return [x['symbol'] for x in spx]
+
+    def batch_price_quote(self, symbols: List[str]):
+        assert len(symbols) > 0
+        return self.make_request(
+            'batch-quote-short',
+            {
+                'symbols': ','.join(symbols),
+            }
+        )
+
+    def batch_market_cap(self, symbols: List[str]):
+        assert len(symbols) > 0
+        return self.make_request(
+            'market-capitalization-batch',
+            {
+                'symbols': ','.join(symbols),
+            }
+        )
     
 
 # Example usage

--- a/utils/graph.py
+++ b/utils/graph.py
@@ -10,6 +10,8 @@ def per_group_return_graph(data, cut_column, min_value, max_value, num_bins=40, 
     assert 'win_spx' in data.columns
     assert 'symbol' in data.columns
 
+    assert sum(data[cut_column].between(min_value, max_value)) > 0, f"No data in {cut_column} between {min_value} and {max_value}"
+
     NUM_BINS = num_bins
     data = data[data[cut_column].between(min_value, max_value)].copy().reset_index(drop=True)
     data = data.replace([np.inf, -np.inf], np.nan)
@@ -29,7 +31,7 @@ def per_group_return_graph(data, cut_column, min_value, max_value, num_bins=40, 
     x = pd.cut(data[cut_column], bins=NUM_BINS, labels=labels)
     y = data.groupby(x, observed=False).agg({"spx_return": "mean", "return": "mean", "symbol": "count", "win_spx": "mean"}).reset_index()
 
-    plt.figure(figsize=(20, 8))
+    plt.figure(figsize=(50, 8))
     bars = plt.bar(y[cut_column], y['return'], edgecolor='black')
     plt.plot(y[cut_column], y['win_spx'], '-o', color='#0c1ef2', linewidth=1, markersize=7, zorder=3)
     plt.legend([bars.get_children()[0], plt.gca().get_lines()[0]], 


### PR DESCRIPTION
# What

This PR allows the creation of screener that's based on current realtime quote of a stock.

# How

Use FMP's batch quote/market cap API. From experiment, I found the limit is 1000 symbols. Since we need ~5000 quotes at most, this can be done very fast.