### PR TITLE
[infra] add measure function for momentum calculation

### DIFF
--- a/fmp_fetch/fmp_online.py
+++ b/fmp_fetch/fmp_online.py
@@ -177,7 +177,7 @@ class FMPOnline:
         self.logger.info(f"Fetching close prices for {len(symbols)} symbols from {start_date} to {end_date}")
         
         all_data = []
-        for symbol in tqdm(symbols):
+        for symbol in tqdm(symbols, desc="Fetching close prices"):
             if symbol.startswith('^'): # symbols start with '^' are index symbols need a different API endpoint
                 prices = self.api.index_prices(symbol, start_date, end_date)
                 for price in prices:

--- a/test/utils/test_measure.py
+++ b/test/utils/test_measure.py
@@ -1,0 +1,426 @@
+import numpy as np
+import pandas as pd
+import pytest
+from datetime import datetime, timedelta
+from utils.measure import _below_vs_chord_sliding, below_chord, TOLERANCE
+from typing import Tuple
+
+
+def _below_vs_chord_sliding_reference(df: pd.DataFrame, window: int, price_col='price') -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Reference implementation using for-loop for cross-verification.
+    Should produce identical results to the vectorized version.
+    """
+    # Ensure sorted and extract price series
+    s = df.sort_values('date').set_index('date')[price_col].astype(float)
+    prices = s.to_numpy()
+    N = window
+    
+    if len(prices) <= N:
+        raise ValueError(f"Need > {N} rows of price data")
+    
+    # Initialize result arrays
+    n_windows = len(prices) - N
+    count_below = np.zeros(n_windows, dtype=int)
+    mask_data = np.zeros((n_windows, N-1), dtype=bool)
+    
+    # Process each window
+    for i in range(n_windows):
+        # Get window prices
+        window_prices = prices[i:i+N+1]
+        
+        # Calculate chord line for this window
+        y0 = window_prices[0]    # Start price
+        yN = window_prices[-1]   # End price
+        
+        # Check each interior point
+        below_count = 0
+        for j in range(1, N):  # Interior points (exclude endpoints)
+            # Position in window (0 to N)
+            k = j
+            # Expected price on chord at this position
+            chord_price = y0 + (k / N) * (yN - y0)
+            
+            # Check if actual price is below chord (with tolerance)
+            actual_price = window_prices[j]
+            is_below = actual_price + TOLERANCE < chord_price
+            
+            if is_below:
+                below_count += 1
+            
+            # Store in mask - vectorized version uses interior_cmp directly
+            # interior_cmp has shape (n_windows, N-1) where columns 0 to N-2 correspond to positions 1 to N-1
+            # So position j (1 to N-1) maps to column j-1 (0 to N-2)
+            mask_data[i, j-1] = is_below
+        
+        count_below[i] = below_count
+    
+    # Create output DataFrames
+    share_below = count_below / (N - 1)
+    end_idx = s.index[N:]  # window ends at these dates
+    
+    out = pd.DataFrame({
+        'count_below': count_below, 
+        'share_below': share_below
+    }, index=end_idx)
+    
+    cols = pd.Index(range(N-1, 0, -1), name='days_ago')  # (N-1)..1
+    mask_df = pd.DataFrame(mask_data, index=end_idx, columns=cols)
+    
+    return out, mask_df
+
+
+def test_below_chord_with_linear_price():
+    """Test with a perfectly linear price series - all points should be on the chord."""
+    # Create a linear price series
+    dates = pd.date_range(start='2020-01-01', periods=100)
+    prices = np.linspace(100, 200, 100)  # Linear from 100 to 200
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # With a linear price series and tolerance, all points should be exactly on the chord
+    out, mask = _below_vs_chord_sliding(df, window=30)
+    
+    # All counts should be 0 (no points below chord with tolerance)
+    assert np.all(out['count_below'] == 0)
+    assert np.all(out['share_below'] == 0)
+    assert not mask.any().any()  # No True values in mask
+
+
+def test_below_chord_with_sine_wave():
+    """Test with a sine wave where we can predict the pattern of below/above."""
+    # Create 200 days with a sine wave pattern added to linear trend
+    dates = pd.date_range(start='2020-01-01', periods=200)
+    
+    # Linear component (slope=1)
+    linear = np.arange(200)
+    
+    # Sine component (period=60 days, amplitude=10)
+    sine = 10 * np.sin(2 * np.pi * np.arange(200) / 60)
+    
+    # Combined price
+    prices = 100 + linear + sine
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # Compare vectorized and reference implementations
+    vectorized_out, vectorized_mask = _below_vs_chord_sliding(df, window=60)
+    reference_out, reference_mask = _below_vs_chord_sliding_reference(df, window=60)
+    
+    # Ensure both implementations produce identical results
+    pd.testing.assert_frame_equal(vectorized_out, reference_out, check_dtype=False)
+    pd.testing.assert_frame_equal(vectorized_mask, reference_mask, check_dtype=False)
+    
+    # With window=60 (exactly one period), the chord connects points with the same phase
+    # So approximately half the points should be below the chord
+    out, mask = vectorized_out, vectorized_mask
+    
+    # Check that the share_below is close to 0.5 for most windows
+    # We allow some margin because of edge effects
+    middle_indices = slice(30, 90)  # Examine windows away from edges
+    assert 0.45 <= out.iloc[middle_indices]['share_below'].mean() <= 0.55
+    
+    # For a 60-day window, we expect the pattern to repeat
+    # The share_below should be similar for windows that are 60 days apart
+    for i in range(30, 60):
+        if i + 60 < len(out):
+            assert abs(out['share_below'].iloc[i] - out['share_below'].iloc[i + 60]) < 0.1
+
+
+def test_below_chord_with_step_function():
+    """Test with a step function where we know exactly what should be below/above."""
+    # Create a price series with a step in the middle
+    dates = pd.date_range(start='2020-01-01', periods=100)
+    prices = np.ones(100) * 100
+    prices[50:] = 200  # Step up at day 50
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # Compare vectorized and reference implementations
+    vectorized_out, vectorized_mask = _below_vs_chord_sliding(df, window=60)
+    reference_out, reference_mask = _below_vs_chord_sliding_reference(df, window=60)
+    
+    # Ensure both implementations produce identical results
+    pd.testing.assert_frame_equal(vectorized_out, reference_out, check_dtype=False)
+    pd.testing.assert_frame_equal(vectorized_mask, reference_mask, check_dtype=False)
+    
+    # For a window that spans the step (e.g., day 20 to day 80)
+    # All points before the step should be below the chord
+    out, mask = vectorized_out, vectorized_mask
+    
+    # Check window that starts at day 20 (ends at day 80)
+    # Days 21-49 should be below chord (29 days), days 50-79 should be above
+    window_20_idx = 20
+    expected_below = 29  # Days 21-49 are below (29 days)
+    assert out['count_below'].iloc[window_20_idx] == expected_below
+    assert out['share_below'].iloc[window_20_idx] == expected_below / 59  # 59 interior points
+    
+    # Days 21-49 should be below (True in mask), days 50-79 should not be below
+    assert mask.iloc[window_20_idx, :29].all()  # First 29 days (days 21-49) below
+    assert not mask.iloc[window_20_idx, 29:].any()  # Remaining days not below
+
+
+def test_below_chord_with_real_pattern():
+    """Test with a more realistic price pattern: uptrend with pullbacks."""
+    # Create a price series with an uptrend but periodic pullbacks
+    dates = pd.date_range(start='2020-01-01', periods=200)
+    
+    # Base uptrend
+    trend = np.linspace(100, 200, 200)
+    
+    # Add pullbacks every 20 days (use fixed seed for reproducible results)
+    np.random.seed(42)
+    pullbacks = np.zeros(200)
+    for i in range(20, 200, 20):
+        pullback_size = np.random.uniform(5, 15)  # Random pullback between 5-15%
+        pullback_length = np.random.randint(3, 8)  # Random length between 3-7 days
+        pullbacks[i:i+pullback_length] = -pullback_size
+    
+    # Cumulative effect of pullbacks
+    cumulative_effect = np.cumsum(pullbacks)
+    
+    # Final price
+    prices = trend + cumulative_effect
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # Compare vectorized and reference implementations
+    vectorized_out, vectorized_mask = _below_vs_chord_sliding(df, window=60)
+    reference_out, reference_mask = _below_vs_chord_sliding_reference(df, window=60)
+    
+    # Ensure both implementations produce identical results
+    pd.testing.assert_frame_equal(vectorized_out, reference_out, check_dtype=False)
+    pd.testing.assert_frame_equal(vectorized_mask, reference_mask, check_dtype=False)
+    
+    # With a 60-day window, pullbacks should create periods with points below the chord
+    out, mask = vectorized_out, vectorized_mask
+    
+    # We expect some windows to have significant below-chord counts
+    assert out['count_below'].max() > 10
+    
+    # Since we're using random pullbacks, the exact share below can vary
+    # Just check that it's in a reasonable range
+    assert 0.3 < out['share_below'].mean() < 0.7
+    
+    # Check that pullback periods correspond to below-chord points
+    # For each major pullback, verify nearby windows show increased below-chord counts
+    for i in range(20, 140, 20):  # Check pullbacks within our window range
+        nearby_windows = out.iloc[max(0, i-10):min(len(out), i+10)]
+        assert nearby_windows['count_below'].max() > 5  # At least some below-chord points
+
+
+def test_below_chord_with_symbols():
+    """Test the by-symbol function with multiple stocks."""
+    # Create price data for 3 symbols with different patterns
+    dates = pd.date_range(start='2020-01-01', periods=100)
+    
+    # Symbol 1: Linear uptrend
+    prices1 = np.linspace(100, 200, 100)
+    
+    # Symbol 2: Downtrend
+    prices2 = np.linspace(200, 100, 100)
+    
+    # Symbol 3: Flat with spike
+    prices3 = np.ones(100) * 100
+    prices3[40:60] = 150  # Spike in the middle
+    
+    # Combine into one DataFrame
+    df = pd.DataFrame({
+        'date': dates.tolist() * 3,
+        'symbol': ['AAPL'] * 100 + ['MSFT'] * 100 + ['GOOG'] * 100,
+        'price': np.concatenate([prices1, prices2, prices3])
+    })
+    
+    # Apply the by-symbol function
+    result = below_chord(df, window=30)
+    
+    # Check that all original rows are preserved
+    assert len(result) == len(df)
+    
+    # Check that the new columns are added
+    assert 'below_chord_count' in result.columns
+    assert 'below_chord_share' in result.columns
+    
+    # Check symbol-specific patterns
+    
+    # Symbol 1 (uptrend): Linear trend should have no below-chord points with tolerance
+    aapl_data = result[result['symbol'] == 'AAPL']
+    assert aapl_data['below_chord_count'].max() == 0
+    assert aapl_data['below_chord_share'].max() == 0
+    
+    # Symbol 2 (downtrend): Should have many below-chord points
+    msft_data = result[result['symbol'] == 'MSFT']
+    # For a linear downtrend, most interior points should be above the chord
+    # (chord connects higher start to lower end, so middle points are above)
+    assert msft_data['below_chord_count'].max() == 0
+    assert msft_data['below_chord_share'].max() == 0
+    
+    # Symbol 3 (spike): Should have mixed pattern
+    goog_data = result[result['symbol'] == 'GOOG']
+    
+    # For flat with spike pattern, we need to check windows that include the spike
+    # Windows that include the spike should have some below points
+    spike_windows = goog_data.iloc[40:70]  # Windows that include the spike
+    assert spike_windows['below_chord_count'].max() > 0
+
+
+def test_below_chord_with_missing_data():
+    """Test with missing data points to ensure robust handling."""
+    # Create a price series with some NaN values
+    dates = pd.date_range(start='2020-01-01', periods=100)
+    prices = np.linspace(100, 200, 100)
+    
+    # Insert some NaN values
+    prices[10:15] = np.nan  # 5 consecutive NaNs
+    prices[30] = np.nan     # Single NaN
+    prices[50:52] = np.nan  # 2 consecutive NaNs
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # Apply the function - it should handle NaNs gracefully
+    out, mask = _below_vs_chord_sliding(df.dropna(), window=30)
+    
+    # Check that we get results (fewer than original due to NaNs and window)
+    assert len(out) > 0
+    assert not out['share_below'].isna().any()  # No NaNs in output
+    
+    # The windows containing NaNs should be excluded
+    assert len(out) < len(df) - 30  # Fewer windows than expected without NaNs
+
+
+def test_below_chord_with_extreme_values():
+    """Test with extreme price changes to ensure numerical stability."""
+    # Create a price series with extreme spikes and crashes
+    dates = pd.date_range(start='2020-01-01', periods=100)
+    prices = np.ones(100) * 100
+    
+    # Add extreme spike
+    prices[30] = 10000  # 100x spike
+    
+    # Add extreme crash
+    prices[60] = 1  # 99% crash
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # The function should handle extreme values without crashing
+    out, mask = _below_vs_chord_sliding(df, window=20)
+    
+    # Basic sanity checks
+    assert len(out) > 0
+    assert not out.isna().any().any()
+    assert not mask.isna().any().any()
+    
+    # Windows containing extreme values should show significant below-chord activity
+    extreme_windows = out.iloc[20:80]  # Windows that might include extreme values
+    assert extreme_windows['count_below'].max() > 0
+
+
+def test_vectorized_vs_reference_implementation():
+    """Test that vectorized and for-loop implementations produce identical results."""
+    # Test with multiple different data patterns
+    test_cases = [
+        # Linear uptrend
+        {
+            'name': 'linear_uptrend',
+            'dates': pd.date_range(start='2020-01-01', periods=50),
+            'prices': np.linspace(100, 200, 50)
+        },
+        # Linear downtrend
+        {
+            'name': 'linear_downtrend', 
+            'dates': pd.date_range(start='2020-01-01', periods=50),
+            'prices': np.linspace(200, 100, 50)
+        },
+        # Sine wave
+        {
+            'name': 'sine_wave',
+            'dates': pd.date_range(start='2020-01-01', periods=100),
+            'prices': 100 + 50 * np.sin(2 * np.pi * np.arange(100) / 20)
+        },
+        # Step function
+        {
+            'name': 'step_function',
+            'dates': pd.date_range(start='2020-01-01', periods=60),
+            'prices': np.concatenate([np.ones(30) * 100, np.ones(30) * 200])
+        },
+        # Random walk
+        {
+            'name': 'random_walk',
+            'dates': pd.date_range(start='2020-01-01', periods=80),
+            'prices': 100 + np.cumsum(np.random.randn(80) * 2)
+        }
+    ]
+    
+    for case in test_cases:
+        df = pd.DataFrame({
+            'date': case['dates'],
+            'price': case['prices']
+        })
+        
+        # Test with different window sizes
+        for window in [10, 20, 30]:
+            if len(df) > window:
+                # Get results from both implementations
+                vectorized_out, vectorized_mask = _below_vs_chord_sliding(df, window=window)
+                reference_out, reference_mask = _below_vs_chord_sliding_reference(df, window=window)
+                
+                # Compare summary DataFrames
+                pd.testing.assert_frame_equal(
+                    vectorized_out, reference_out,
+                    check_dtype=False,  # Allow int vs int64 differences
+                    rtol=1e-10, atol=1e-10
+                )
+                
+                # Compare mask DataFrames
+                pd.testing.assert_frame_equal(
+                    vectorized_mask, reference_mask,
+                    check_dtype=False
+                )
+
+
+def test_implementations_with_tolerance_edge_cases():
+    """Test both implementations handle tolerance edge cases identically."""
+    # Create data where prices are exactly at tolerance boundary
+    dates = pd.date_range(start='2020-01-01', periods=50)
+    
+    # Linear trend with small deviations at tolerance boundary
+    base_prices = np.linspace(100, 200, 50)
+    
+    # Add small deviations that are exactly at the tolerance boundary
+    deviations = np.zeros(50)
+    deviations[10] = -TOLERANCE * 0.9  # Just within tolerance
+    deviations[20] = -TOLERANCE * 1.1  # Just outside tolerance
+    deviations[30] = TOLERANCE * 0.9   # Positive deviation within tolerance
+    
+    prices = base_prices + deviations
+    
+    df = pd.DataFrame({
+        'date': dates,
+        'price': prices
+    })
+    
+    # Test with window that includes the tolerance edge cases
+    vectorized_out, vectorized_mask = _below_vs_chord_sliding(df, window=30)
+    reference_out, reference_mask = _below_vs_chord_sliding_reference(df, window=30)
+    
+    # Results should be identical
+    pd.testing.assert_frame_equal(vectorized_out, reference_out, check_dtype=False)
+    pd.testing.assert_frame_equal(vectorized_mask, reference_mask, check_dtype=False)

--- a/utils/graph.py
+++ b/utils/graph.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt 
-from typing import List
+from typing import List, Dict
+from fmp_data import OfflineData
 
 def per_group_return_graph(data, cut_column, min_value, max_value, num_bins=40, extra_title=""):
     assert cut_column in data.columns
@@ -129,4 +130,16 @@ def price_history_graph(data: List[pd.DataFrame], title=""):
     plt.ylabel("Relative Price")
     plt.xlabel("Time")
     plt.title(title)
+    
+def price_history_range(symbols: List[str], start_date: str, end_date: str, mark_dates: Dict[str, str] = {}):
+    import logging
+    logging.getLogger('matplotlib').setLevel(logging.WARNING)
+    for s in symbols:
+        d = OfflineData.historical_tradable_price(s, start_date, end_date)
+        plt.plot(d.date, d.tradable_price, label=s)
+        for date, label in mark_dates.items():
+            plt.axvline(x=date, color='r', linestyle='--', label=label)
+    plt.gca().xaxis.set_major_locator(plt.MaxNLocator(10))
+    plt.legend()
+    plt.show()
     

--- a/utils/measure.py
+++ b/utils/measure.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pandas as pd
+from numpy.lib.stride_tricks import sliding_window_view
+from typing import Tuple
+
+TOLERANCE = 1e-3
+
+
+def _below_vs_chord_sliding(df: pd.DataFrame, window: int, price_col='price') -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Implementation using numpy's sliding_window_view for maximum performance.
+    
+    Args:
+        df: DataFrame with at least columns: date, <price_col>
+        window: Window size for the chord
+        price_col: Column name for the price series
+    
+    Returns:
+        Tuple of (summary_df, mask_df):
+        - summary_df: DataFrame with share_below and count_below per end date
+        - mask_df: Boolean DataFrame where True means price was below the chord
+    """
+    # Ensure sorted and extract price series
+    s = df.sort_values('date').set_index('date')[price_col].astype(float)
+    p = s.to_numpy()
+    N = window
+    
+    if len(p) <= N:
+        raise ValueError(f"Need > {N} rows of price data")
+
+    # Create 2D view of rolling windows: shape (n-N, N+1)
+    w = sliding_window_view(p, window_shape=N+1)
+
+    # Build the chord for each window via broadcasting
+    y0 = w[:, [0]]           # (n-N, 1) - price at t-window
+    yN = w[:, [-1]]          # (n-N, 1) - price at t
+    k = np.arange(N+1)[None, :]  # (1, N+1) - position in window
+    y_line = y0 + (k / N) * (yN - y0)  # chord equation
+
+    # Compare interior points to chord (exclude endpoints which lie on the chord)
+    interior_cmp = w[:, 1:-1] + TOLERANCE < y_line[:, 1:-1]  # (n-N, N-1) - True if below
+
+    # Aggregates per end date
+    count_below = interior_cmp.sum(axis=1)
+    share_below = count_below / (N - 1)
+
+    # Return as DataFrames
+    end_idx = s.index[N:]  # window ends at these dates
+    cols = pd.Index(range(N-1, 0, -1), name='days_ago')  # (N-1)..1
+    mask_df = pd.DataFrame(interior_cmp, index=end_idx, columns=cols)
+    out = pd.DataFrame({
+        'count_below': count_below, 
+        'share_below': share_below
+    }, index=end_idx)
+    
+    return out, mask_df
+
+def below_chord(df: pd.DataFrame, window: int, price_col='price') -> pd.DataFrame:
+    """
+    Calculate the percentage of days below the chord, grouped by symbol.
+    
+    Args:
+        df: DataFrame with columns: date, symbol, <price_col>
+        window: Window size for the chord
+        price_col: Column name for the price series
+    
+    Returns:
+        Original DataFrame with additional columns:
+        - below_chord_count: number of interior days where price was below the chord
+        - below_chord_share: fraction of interior days where price was below the chord
+    """
+    # Ensure we have required columns
+    if 'symbol' not in df.columns:
+        raise ValueError("DataFrame must contain 'symbol' column")
+    if 'date' not in df.columns:
+        raise ValueError("DataFrame must contain 'date' column")
+    
+    # Create a copy of the input DataFrame
+    result_df = df.copy()
+    
+    # Calculate metrics for each symbol group and collect in a list
+    all_metrics = []
+    
+    for symbol, group in df.groupby('symbol'):
+        # Get the chord metrics for this symbol
+        metrics_df, _ = _below_vs_chord_sliding(group, window=window, price_col=price_col)
+        
+        # Add symbol column to metrics
+        metrics_df = metrics_df.reset_index()
+        metrics_df['symbol'] = symbol
+        
+        # Rename columns to match requested names
+        metrics_df = metrics_df.rename(columns={
+            'count_below': 'below_chord_count',
+            'share_below': 'below_chord_share'
+        })
+        
+        all_metrics.append(metrics_df)
+    
+    # Combine all metrics
+    if not all_metrics:
+        # No metrics calculated, return original DataFrame
+        return result_df
+    
+    combined_metrics = pd.concat(all_metrics)
+    
+    # Merge metrics back to original DataFrame
+    result_df = pd.merge(
+        result_df, 
+        combined_metrics[['symbol', 'date', 'below_chord_count', 'below_chord_share']], 
+        on=['symbol', 'date'], 
+        how='left'
+    )
+    
+    return result_df


### PR DESCRIPTION
# What

1. Add `below_chord` function to measure.py. It calculates how many price point is under the linear line of a price history chart. This can be used to flag price appreciation at "hyper linear" speed.
2. Minor fixes/refact on various functions.